### PR TITLE
Make image_url ivar being accessible from Quiz entity perspective

### DIFF
--- a/lib/quiz_scraper/scrapers/geeks_who_drink.rb
+++ b/lib/quiz_scraper/scrapers/geeks_who_drink.rb
@@ -26,6 +26,7 @@ module QuizScraper
           reference: reference,
           location: location,
           quiz_day: quiz_day,
+          image_url: nil,
           raw_data: raw_data
         }
       end


### PR DESCRIPTION
-> GeeksWhoDrink do not provide image_urls but it's always better to
   keep cohesion in between instantiated Quiz entities.